### PR TITLE
[In Progress] Feature: Create Circle

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.34",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.12",
+    "@fortawesome/free-regular-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.6.3",
     "@fortawesome/react-fontawesome": "^0.1.3",
     "@material-ui/core": "^4.6.0",

--- a/src/Annotator/index.js
+++ b/src/Annotator/index.js
@@ -35,7 +35,7 @@ export default ({
   showPointDistances,
   pointDistancePrecision,
   showTags = true,
-  enabledTools = ["select", "create-point", "create-box", "create-polygon"],
+  enabledTools = ["select", "create-point", "create-box", "create-polygon", "create-circle"],
   regionTagList = [],
   regionClsList = [],
   imageTagList = [],

--- a/src/Annotator/reducer.js
+++ b/src/Annotator/reducer.js
@@ -185,16 +185,16 @@ export default (state: MainLayoutState, action: Action) => {
       })
     }
     case "BEGIN_CIRCLE_TRANSFORM": {
-      debugger;
-      const { region, directions } = action
+      // debugger;
+      const { circle, directions } = action
       state = closeEditors(state)
-      if (directions[0] === 0 && directions[1] === 0) {
-        return setIn(state, ["mode"], { mode: "MOVE_REGION", regionId: region.id })
+      if (directions === "MOVE_REGION") {
+        return setIn(state, ["mode"], { mode: "MOVE_REGION", regionId: circle.id })
       } else {
         return setIn(state, ["mode"], {
           mode: "RESIZE_CIRCLE",
-          regionId: region.id,
-          original: {x: x, y: y, xr: region.xr, yr: region.yr}
+          regionId: circle.id,
+          original: {x: x, y: y, xr: circle.xr, yr: circle.yr}
         })
       }
     }

--- a/src/Annotator/reducer.js
+++ b/src/Annotator/reducer.js
@@ -188,12 +188,15 @@ export default (state: MainLayoutState, action: Action) => {
       const { circle, directions } = action
       state = closeEditors(state)
       if (directions === "MOVE_REGION") {
-        return setIn(state, ["mode"], { mode: "MOVE_REGION", regionId: circle.id })
+        return setIn(state, ["mode"], {
+          mode: "MOVE_REGION",
+          regionId: circle.id
+        })
       } else {
         return setIn(state, ["mode"], {
           mode: "RESIZE_CIRCLE",
           regionId: circle.id,
-          original: {x: circle.x, y: circle.y, xr: circle.xr, yr: circle.yr}
+          original: { x: circle.x, y: circle.y, rx: circle.rx, ry: circle.ry }
         })
       }
     }
@@ -330,7 +333,11 @@ export default (state: MainLayoutState, action: Action) => {
           return setIn(
             state,
             ["images", currentImageIndex, "regions", regionIndex],
-            { ...region, xr: action.x, yr: action.y }
+            {
+              ...region,
+              xr: Math.abs(region.x - x),
+              yr: Math.abs(region.y - y)
+            }
           )
         }
         case "DRAW_POLYGON": {
@@ -427,8 +434,8 @@ export default (state: MainLayoutState, action: Action) => {
               type: "circle",
               x: x,
               y: y,
-              xr: 0.00000000001,
-              yr: 0.00000000001,
+              xr: 0.1,
+              yr: 0.1,
               highlighted: true,
               editingLabels: false,
               color: getRandomColor(),
@@ -439,7 +446,7 @@ export default (state: MainLayoutState, action: Action) => {
               mode: "RESIZE_CIRCLE",
               editLabelEditorAfter: true,
               regionId: newRegion.id,
-              original: {x: x, y: y, xr: newRegion.xr, yr: newRegion.yr}
+              original: { x: x, y: y, xr: newRegion.xr, yr: newRegion.yr }
             })
             break
           }

--- a/src/Annotator/reducer.js
+++ b/src/Annotator/reducer.js
@@ -185,7 +185,6 @@ export default (state: MainLayoutState, action: Action) => {
       })
     }
     case "BEGIN_CIRCLE_TRANSFORM": {
-      // debugger;
       const { circle, directions } = action
       state = closeEditors(state)
       if (directions === "MOVE_REGION") {
@@ -194,7 +193,7 @@ export default (state: MainLayoutState, action: Action) => {
         return setIn(state, ["mode"], {
           mode: "RESIZE_CIRCLE",
           regionId: circle.id,
-          original: {x: x, y: y, xr: circle.xr, yr: circle.yr}
+          original: {x: circle.x, y: circle.y, xr: circle.xr, yr: circle.yr}
         })
       }
     }

--- a/src/Annotator/reducer.js
+++ b/src/Annotator/reducer.js
@@ -331,8 +331,6 @@ export default (state: MainLayoutState, action: Action) => {
             state,
             ["images", currentImageIndex, "regions", regionIndex],
             { ...region, xr: action.x, yr: action.y }
-            // region.radius+1
-            // Math.sqrt(Math.pow(region.x - x,2) + Math.pow(region.y - y,2))
           )
         }
         case "DRAW_POLYGON": {

--- a/src/Annotator/reducer.js
+++ b/src/Annotator/reducer.js
@@ -194,7 +194,7 @@ export default (state: MainLayoutState, action: Action) => {
         return setIn(state, ["mode"], {
           mode: "RESIZE_CIRCLE",
           regionId: region.id,
-          original: {x: x, y: y, radius: region.radius}
+          original: {x: x, y: y, xr: region.xr, yr: region.yr}
         })
       }
     }
@@ -331,7 +331,7 @@ export default (state: MainLayoutState, action: Action) => {
           return setIn(
             state,
             ["images", currentImageIndex, "regions", regionIndex],
-            { ...region, radius: Math.sqrt(Math.pow(region.x - action.x,2) + Math.pow(region.y - action.y,2)) }
+            { ...region, xr: action.x, yr: action.y }
             // region.radius+1
             // Math.sqrt(Math.pow(region.x - x,2) + Math.pow(region.y - y,2))
           )
@@ -429,8 +429,9 @@ export default (state: MainLayoutState, action: Action) => {
             newRegion = {
               type: "circle",
               x: x,
-              y: x,
-              radius: 0.01,
+              y: y,
+              xr: 0.00000000001,
+              yr: 0.00000000001,
               highlighted: true,
               editingLabels: false,
               color: getRandomColor(),
@@ -441,7 +442,7 @@ export default (state: MainLayoutState, action: Action) => {
               mode: "RESIZE_CIRCLE",
               editLabelEditorAfter: true,
               regionId: newRegion.id,
-              original: {x: x, y: y, radius: newRegion.radius}
+              original: {x: x, y: y, xr: newRegion.xr, yr: newRegion.yr}
             })
             break
           }

--- a/src/IconTools/index.js
+++ b/src/IconTools/index.js
@@ -12,7 +12,8 @@ import {
   faDrawPolygon,
   faVectorSquare,
   faHandPaper,
-  faSearch
+  faSearch,
+  faCircle
 } from "@fortawesome/free-solid-svg-icons"
 import SmallToolButton, { SelectedTool } from "../SmallToolButton"
 import { makeStyles } from "@material-ui/core/styles"
@@ -41,7 +42,7 @@ export default ({
   showTags,
   selectedTool,
   onClickTool,
-  enabledTools = ["select", "create-point", "create-box", "create-polygon"]
+  enabledTools = ["select", "create-point", "create-box", "create-polygon", "create-circle"]
 }: Props) => {
   const classes = useStyles()
   return (
@@ -98,6 +99,11 @@ export default ({
           id="create-polygon"
           name="Add Polygon"
           icon={<FontAwesomeIcon size="xs" fixedWidth icon={faDrawPolygon} />}
+        />
+        <SmallToolButton
+          id="create-circle"
+          name="Add Circle"
+          icon={<FontAwesomeIcon size="xs" fixedWidth icon={faCircle} />}
         />
         {/* <SmallToolButton
           id="create-pixel"

--- a/src/IconTools/index.js
+++ b/src/IconTools/index.js
@@ -12,9 +12,9 @@ import {
   faDrawPolygon,
   faVectorSquare,
   faHandPaper,
-  faSearch,
-  faCircle
+  faSearch
 } from "@fortawesome/free-solid-svg-icons"
+import { faCircle } from "@fortawesome/free-regular-svg-icons"
 import SmallToolButton, { SelectedTool } from "../SmallToolButton"
 import { makeStyles } from "@material-ui/core/styles"
 import { grey } from "@material-ui/core/colors"

--- a/src/ImageCanvas/index.js
+++ b/src/ImageCanvas/index.js
@@ -292,7 +292,8 @@ export default ({
           context.shadowBlur = 4
           context.strokeStyle = region.color
           context.beginPath();
-          context.arc(region.x * iw, region.y * ih, region.radius * Math.sqrt(Math.pow(iw,2) + Math.pow(ih,2)) , 0, 2 * Math.PI);
+          context.arc(region.x * iw, region.y * ih,
+             Math.sqrt(Math.pow((region.xr-region.x)*iw,2) + Math.pow((region.yr-region.y)*ih,2)), 0, 2 * Math.PI);
           context.stroke()
           context.restore()
           break

--- a/src/ImageCanvas/index.js
+++ b/src/ImageCanvas/index.js
@@ -235,7 +235,6 @@ export default ({
       switch (region.type) {
         case "point": {
           context.save()
-          // debugger;
 
           context.beginPath()
           context.strokeStyle = region.color
@@ -615,8 +614,6 @@ export default ({
                         style={{
                           left: proj.x - 4,
                           top: proj.y - 4,
-                          // top: pbox.y - 4 - 2 + pbox.h * py,
-                          // cursor: boxCursorMap[py * 2][px * 2],
                           borderRadius: px === r.x && py === r.y ? 4 : undefined
                         }}
                       />

--- a/src/ImageCanvas/index.js
+++ b/src/ImageCanvas/index.js
@@ -117,7 +117,7 @@ export default ({
 
   const projectRegionBox = r => {
     const { iw, ih } = layoutParams.current
-    const bbox = getEnclosingBox(r)
+    const bbox = getEnclosingBox(r, iw, ih)
     const margin = r.type === "point" ? 15 : 2
     const cbox = {
       x: bbox.x * iw - margin,
@@ -590,10 +590,10 @@ export default ({
                   r.highlighted &&
                   [
                     [r.x, r.y],
-                    [r.x + r.xr, r.y],
-                    [r.x, r.y + r.yr],
-                    [r.x - r.xr, r.y],
-                    [r.x, r.y - r.yr]
+                    [(r.x*iw + Math.sqrt(Math.pow((r.xr-r.x)*iw,2) + Math.pow((r.yr-r.y)*ih,2)))/iw, r.y],
+                    [r.x, (r.y*ih + Math.sqrt(Math.pow((r.xr-r.x)*iw,2) + Math.pow((r.yr-r.y)*ih,2)))/ih],
+                    [(r.x*iw - Math.sqrt(Math.pow((r.xr-r.x)*iw,2) + Math.pow((r.yr-r.y)*ih,2)))/iw, r.y],
+                    [r.x, (r.y*ih - Math.sqrt(Math.pow((r.xr-r.x)*iw,2) + Math.pow((r.yr-r.y)*ih,2)))/ih]
                   ].map(([px, py], i) => {
                     const proj = mat
                       .clone()

--- a/src/ImageCanvas/index.js
+++ b/src/ImageCanvas/index.js
@@ -590,10 +590,10 @@ export default ({
                   r.highlighted &&
                   [
                     [r.x, r.y],
-                    [r.x + r.rx, r.y],
-                    [r.x, r.y + r.ry],
-                    [r.x - r.rx, r.y],
-                    [r.x, r.y - r.ry]
+                    [r.x + r.xr, r.y],
+                    [r.x, r.y + r.yr],
+                    [r.x - r.xr, r.y],
+                    [r.x, r.y - r.yr]
                   ].map(([px, py], i) => {
                     const proj = mat
                       .clone()
@@ -607,7 +607,7 @@ export default ({
                         onMouseDown={e => {
                           if (e.button === 0 && i==0){
                             return onBeginCircleTransform(r, "MOVE_REGION")
-                          }else if(e.button === 0 && i==0){
+                          }else if(e.button === 0 && i!=0){
                             return onBeginCircleTransform(r, "RESIZE_CIRCLE")
                           }
                           mouseEvents.onMouseDown(e)

--- a/src/ImageCanvas/index.js
+++ b/src/ImageCanvas/index.js
@@ -8,7 +8,8 @@ import type {
   PixelRegion,
   Point,
   Polygon,
-  Box
+  Box,
+  Circle
 } from "./region-tools.js"
 import { getEnclosingBox } from "./region-tools.js"
 import { makeStyles } from "@material-ui/core/styles"
@@ -53,6 +54,7 @@ type Props = {
   onCloseRegionEdit: Region => any,
   onDeleteRegion: Region => any,
   onBeginBoxTransform: (Box, [number, number]) => any,
+  onBeginCircleTransform: (Circle) => any,
   onBeginMovePolygonPoint: (Polygon, index: number) => any,
   onAddPolygonPoint: (Polygon, point: [number, number], index: number) => any,
   onSelectRegion: Region => any,
@@ -84,6 +86,7 @@ export default ({
   onChangeRegion,
   onBeginRegionEdit,
   onCloseRegionEdit,
+  onBeginCircleTransform,
   onBeginBoxTransform,
   onBeginMovePolygonPoint,
   onAddPolygonPoint,
@@ -232,6 +235,7 @@ export default ({
       switch (region.type) {
         case "point": {
           context.save()
+          // debugger;
 
           context.beginPath()
           context.strokeStyle = region.color
@@ -278,6 +282,17 @@ export default ({
             context.lineTo(point[0] * iw, point[1] * ih)
           }
           if (!region.open) context.closePath()
+          context.stroke()
+          context.restore()
+          break
+        }
+        case "circle": {
+          context.save()
+          context.shadowColor = "black"
+          context.shadowBlur = 4
+          context.strokeStyle = region.color
+          context.beginPath();
+          context.arc(region.x * iw, region.y * ih, region.radius * Math.sqrt(Math.pow(iw,2) + Math.pow(ih,2)) , 0, 2 * Math.PI);
           context.stroke()
           context.restore()
           break
@@ -566,6 +581,22 @@ export default ({
                       }}
                     />
                   ))}
+                {
+                  r.type === "circle" &&
+                  !dragWithPrimary &&
+                  !zoomWithPrimary &&
+                  !r.locked &&
+                  r.highlighted &&
+                  <div
+                    key={1}
+                    {...mouseEvents}
+                    onMouseDown={e => {
+                      if (e.button === 0)
+                        return onBeginCircleTransform(r)
+                      mouseEvents.onMouseDown(e)
+                    }}
+                  />
+                }
                 {r.type === "polygon" &&
                   !dragWithPrimary &&
                   !zoomWithPrimary &&

--- a/src/ImageCanvas/region-tools.js
+++ b/src/ImageCanvas/region-tools.js
@@ -54,15 +54,14 @@ export type Circle = {|
   // x and y indicate the coordinates of the centre of the circle
   x: number,
   y: number,
-  // xr and yr indicate the x radius and y radius. Note that the coordinates are
-  // transformed. Hence, I'm keeping them both.
+  // xr and yr indicate the x and y coordinates of the current mouse pointer while dragging.
   xr: number,
   yr: number
 |}
 
 export type Region = Point | PixelRegion | Box | Polygon
 
-export const getEnclosingBox = (region: Region) => {
+export const getEnclosingBox = (region: Region, iw: number, ih: number) => {
   switch (region.type) {
     case "polygon": {
       const box = {
@@ -103,12 +102,16 @@ export const getEnclosingBox = (region: Region) => {
       }
     }
     case "circle": {
-      return {
-        x: region.x-region.xr,
-        y: region.y-region.yr,
-        w: region.x+region.xr,
-        h: region.y+region.yr
+      const radius = Math.sqrt(Math.pow((region.xr-region.x)*iw,2) + Math.pow((region.yr-region.y)*ih,2))
+      const box = {
+        x: (region.x*iw - radius)/iw,
+        y: (region.y*ih - radius)/ih,
+        w: 0,
+        h: 0
       }
+      box.w = (region.x*iw + radius)/iw - box.x
+      box.h = (region.y*ih + radius)/ih - box.y
+      return box
     }
   }
   throw new Error("unknown region")

--- a/src/ImageCanvas/region-tools.js
+++ b/src/ImageCanvas/region-tools.js
@@ -122,6 +122,9 @@ export const moveRegion = (region: Region, x: number, y: number) => {
     case "box": {
       return { ...region, x: x - region.w / 2, y: y - region.h / 2 }
     }
+    case "circle": {
+      return { ...region, x, y, xr: region.xr + x - region.x, yr: region.yr + y - region.y }
+    }
   }
   return region
 }

--- a/src/ImageCanvas/region-tools.js
+++ b/src/ImageCanvas/region-tools.js
@@ -50,18 +50,17 @@ export type Polygon = {|
 export type Circle = {|
   ...$Exact<BaseRegion>,
   type: "circle",
-  // radius: number,
   // x and y indicate the coordinates of the centre of the circle
   x: number,
   y: number,
-  // xr and yr indicate the x and y coordinates of the current mouse pointer while dragging.
+  // x and y radius (technically, Circles are capable of representing Ovals)
   xr: number,
-  yr: number
+  xr: number
 |}
 
 export type Region = Point | PixelRegion | Box | Polygon
 
-export const getEnclosingBox = (region: Region, iw: number, ih: number) => {
+export const getEnclosingBox = (region: Region) => {
   switch (region.type) {
     case "polygon": {
       const box = {
@@ -102,16 +101,12 @@ export const getEnclosingBox = (region: Region, iw: number, ih: number) => {
       }
     }
     case "circle": {
-      const radius = Math.sqrt(Math.pow((region.xr-region.x)*iw,2) + Math.pow((region.yr-region.y)*ih,2))
-      const box = {
-        x: (region.x*iw - radius)/iw,
-        y: (region.y*ih - radius)/ih,
-        w: 0,
-        h: 0
+      return {
+        x: region.x - region.xr,
+        y: region.y - region.yr,
+        w: region.xr * 2,
+        h: region.yr * 2
       }
-      box.w = (region.x*iw + radius)/iw - box.x
-      box.h = (region.y*ih + radius)/ih - box.y
-      return box
     }
   }
   throw new Error("unknown region")
@@ -126,7 +121,11 @@ export const moveRegion = (region: Region, x: number, y: number) => {
       return { ...region, x: x - region.w / 2, y: y - region.h / 2 }
     }
     case "circle": {
-      return { ...region, x, y, xr: region.xr + x - region.x, yr: region.yr + y - region.y }
+      return {
+        ...region,
+        x,
+        y
+      }
     }
   }
   return region

--- a/src/ImageCanvas/region-tools.js
+++ b/src/ImageCanvas/region-tools.js
@@ -47,6 +47,14 @@ export type Polygon = {|
   open?: boolean,
   points: Array<[number, number]>
 |}
+export type Circle = {|
+  ...$Exact<BaseRegion>,
+  type: "circle",
+  radius: number,
+  // x and y indicate the coordinates of the centre of the circle
+  x: number,
+  y: number
+|}
 
 export type Region = Point | PixelRegion | Box | Polygon
 
@@ -88,6 +96,14 @@ export const getEnclosingBox = (region: Region) => {
         box.w = Math.max(...region.points.map(([x, y]) => x)) - box.x
         box.h = Math.max(...region.points.map(([x, y]) => y)) - box.y
         return box
+      }
+    }
+    case "circle": {
+      return {
+        x: region.x-region.radius,
+        y: region.y-region.radius,
+        w: region.x+region.radius,
+        h: region.y+region.radius
       }
     }
   }

--- a/src/ImageCanvas/region-tools.js
+++ b/src/ImageCanvas/region-tools.js
@@ -50,10 +50,14 @@ export type Polygon = {|
 export type Circle = {|
   ...$Exact<BaseRegion>,
   type: "circle",
-  radius: number,
+  // radius: number,
   // x and y indicate the coordinates of the centre of the circle
   x: number,
-  y: number
+  y: number,
+  // xr and yr indicate the x radius and y radius. Note that the coordinates are
+  // transformed. Hence, I'm keeping them both.
+  xr: number,
+  yr: number
 |}
 
 export type Region = Point | PixelRegion | Box | Polygon
@@ -100,10 +104,10 @@ export const getEnclosingBox = (region: Region) => {
     }
     case "circle": {
       return {
-        x: region.x-region.radius,
-        y: region.y-region.radius,
-        w: region.x+region.radius,
-        h: region.y+region.radius
+        x: region.x-region.xr,
+        y: region.y-region.yr,
+        w: region.x+region.xr,
+        h: region.y+region.yr
       }
     }
   }

--- a/src/MainLayout/index.js
+++ b/src/MainLayout/index.js
@@ -102,6 +102,11 @@ export default ({ state, dispatch }: Props) => {
                   onBeginRegionEdit={action("OPEN_REGION_EDITOR", "region")}
                   onCloseRegionEdit={action("CLOSE_REGION_EDITOR", "region")}
                   onDeleteRegion={action("DELETE_REGION", "region")}
+                  onBeginCircleTransform={action(
+                    "BEGIN_CIRCLE_TRANSFORM",
+                    "circle",
+                    "directions"
+                  )}
                   onBeginBoxTransform={action(
                     "BEGIN_BOX_TRANSFORM",
                     "box",

--- a/src/MainLayout/types.js
+++ b/src/MainLayout/types.js
@@ -40,7 +40,7 @@ export type Mode =
       mode: "RESIZE_CIRCLE",
       editLabelEditorAfter?: boolean,
       regionId: string,
-      original: {x: number, y: number, xr: number, yr: number}
+      original: { x: number, y: number, r: number }
     |}
   | {| mode: "MOVE_REGION" |}
 

--- a/src/MainLayout/types.js
+++ b/src/MainLayout/types.js
@@ -75,7 +75,7 @@ export type Action =
   | {| type: "CLOSE_POLYGON", polygon: Polygon |}
   | {| type: "SELECT_REGION", region: Region |}
   | {| type: "BEGIN_MOVE_POINT", point: Point |}
-  | {| type: "BEGIN_CIRCLE_TRANSFORM", region: Circle, directions: [number, number] |}
+  | {| type: "BEGIN_CIRCLE_TRANSFORM", region: Circle, directions: string |}
   | {| type: "BEGIN_BOX_TRANSFORM", box: Box, directions: [number, number] |}
   | {| type: "BEGIN_MOVE_POLYGON_POINT", polygon: Polygon, pointIndex: number |}
   | {|

--- a/src/MainLayout/types.js
+++ b/src/MainLayout/types.js
@@ -36,6 +36,12 @@ export type Mode =
       freedom: [number, number],
       original: { x: number, y: number, w: number, h: number }
     |}
+  | {|
+      mode: "RESIZE_CIRCLE",
+      editLabelEditorAfter?: boolean,
+      regionId: string,
+      original: {x: number, y: number, radius: number}
+    |}
   | {| mode: "MOVE_REGION" |}
 
 export type MainLayoutState = {|
@@ -69,6 +75,7 @@ export type Action =
   | {| type: "CLOSE_POLYGON", polygon: Polygon |}
   | {| type: "SELECT_REGION", region: Region |}
   | {| type: "BEGIN_MOVE_POINT", point: Point |}
+  | {| type: "BEGIN_CIRCLE_TRANSFORM", region: Circle, directions: [number, number] |}
   | {| type: "BEGIN_BOX_TRANSFORM", box: Box, directions: [number, number] |}
   | {| type: "BEGIN_MOVE_POLYGON_POINT", polygon: Polygon, pointIndex: number |}
   | {|

--- a/src/MainLayout/types.js
+++ b/src/MainLayout/types.js
@@ -40,7 +40,7 @@ export type Mode =
       mode: "RESIZE_CIRCLE",
       editLabelEditorAfter?: boolean,
       regionId: string,
-      original: {x: number, y: number, radius: number}
+      original: {x: number, y: number, xr: number, yr: number}
     |}
   | {| mode: "MOVE_REGION" |}
 


### PR DESCRIPTION
Created from #17, this PR creates a new tool "create-circle". Remaining issues:
- [ ] When the create circle tool is selected, clicking the little button to open the classification dialog should not create a new circle
- [ ] The circle tool icon should be a dotted circle
- [ ] (optional) xr and yr should be locked to the image ratio such that the circle isn't an ellipsis

Note: Prettier should be run on any changed files, I installed the prettier extension to my IDE and set it to configure on save to make this easier